### PR TITLE
feat: support statefulset annotation specify ip and ippool

### DIFF
--- a/api/ipam/v1alpha1/types.go
+++ b/api/ipam/v1alpha1/types.go
@@ -50,16 +50,19 @@ type IPPoolStatus struct {
 }
 
 type AllocateInfo struct {
-	ID string `json:"id"`
 	// Type=pod, ID=podns/name
+	ID   string       `json:"id"`
 	Type AllocateType `json:"type,omitempty"`
+	// Type=statefulset, owner=statefulsetns/name
+	Owner string `json:"owner,omitempty"`
 }
 
 type AllocateType string
 
 const (
-	AllocatedTypeCNIUsed AllocateType = "cniused"
-	AllocatedTypePod     AllocateType = "pod"
+	AllocateTypeCNIUsed     AllocateType = "cniused"
+	AllocateTypePod         AllocateType = "pod"
+	AllocateTypeStatefulSet AllocateType = "statefulset"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/deploy/crds/ipam.everoute.io_ippools.yaml
+++ b/deploy/crds/ipam.everoute.io_ippools.yaml
@@ -60,9 +60,12 @@ spec:
                 additionalProperties:
                   properties:
                     id:
+                      description: Type=pod, ID=podns/name
+                      type: string
+                    owner:
+                      description: Type=statefulset, owner=statefulsetns/name
                       type: string
                     type:
-                      description: Type=pod, ID=podns/name
                       type: string
                   required:
                   - id

--- a/pkg/constants/k8s.go
+++ b/pkg/constants/k8s.go
@@ -3,4 +3,7 @@ package constants
 const (
 	IpamAnnotationPool     = "ipam.everoute.io/pool"
 	IpamAnnotationStaticIP = "ipam.everoute.io/static-ip"
+	IpamAnnotationIPList   = "ipam.everoute.io/ip-list"
+
+	KindStatefulSet = "StatefulSet"
 )

--- a/pkg/cron/pod.go
+++ b/pkg/cron/pod.go
@@ -35,7 +35,7 @@ func cleanStaleIPForPod(ctx context.Context, k8sClient client.Client) {
 		}
 		delIPs := make([]string, 0)
 		for ip, allo := range ippool.Status.AllocatedIPs {
-			if allo.Type != v1alpha1.AllocatedTypePod {
+			if allo.Type != v1alpha1.AllocateTypePod {
 				continue
 			}
 			podNsName := utils.GetPodNsNameByAllocateID(allo.ID)

--- a/pkg/cron/pod_test.go
+++ b/pkg/cron/pod_test.go
@@ -101,9 +101,9 @@ var _ = Describe("clean_stale_ip_for_pod", func() {
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &ippool)).Should(Succeed())
 				ippool.Status.Offset = constants.IPPoolOffsetFull
 				ippool.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
-				ippool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypePod, ID: ns + "/" + pod1Name}
-				ippool.Status.AllocatedIPs["10.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypeCNIUsed, ID: "dfgggg"}
-				ippool.Status.AllocatedIPs["10.10.65.3"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypePod, ID: ns + "/" + "pod-unexist"}
+				ippool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + pod1Name}
+				ippool.Status.AllocatedIPs["10.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeCNIUsed, ID: "dfgggg"}
+				ippool.Status.AllocatedIPs["10.10.65.3"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + "pod-unexist"}
 				Expect(k8sClient.Status().Update(ctx, &ippool)).Should(Succeed())
 			})
 			It("clean stale IP", func() {
@@ -131,9 +131,9 @@ var _ = Describe("clean_stale_ip_for_pod", func() {
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &ippool)).Should(Succeed())
 				ippool.Status.Offset = 1
 				ippool.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
-				ippool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypePod, ID: ns + "/" + pod1Name}
-				ippool.Status.AllocatedIPs["10.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypeCNIUsed, ID: "dfgggg"}
-				ippool.Status.AllocatedIPs["10.10.65.3"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypePod, ID: ns + "/" + "pod-unexist"}
+				ippool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + pod1Name}
+				ippool.Status.AllocatedIPs["10.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeCNIUsed, ID: "dfgggg"}
+				ippool.Status.AllocatedIPs["10.10.65.3"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + "pod-unexist"}
 				Expect(k8sClient.Status().Update(ctx, &ippool)).Should(Succeed())
 			})
 			It("clean stale IP", func() {
@@ -163,17 +163,17 @@ var _ = Describe("clean_stale_ip_for_pod", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &ippool)).Should(Succeed())
 			ippool.Status.Offset = 1
 			ippool.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
-			ippool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypePod, ID: ns + "/" + pod1Name}
-			ippool.Status.AllocatedIPs["10.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypeCNIUsed, ID: "dfgggg"}
-			ippool.Status.AllocatedIPs["10.10.65.3"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypePod, ID: ns + "/" + "pod-unexist"}
+			ippool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + pod1Name}
+			ippool.Status.AllocatedIPs["10.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeCNIUsed, ID: "dfgggg"}
+			ippool.Status.AllocatedIPs["10.10.65.3"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + "pod-unexist"}
 			Expect(k8sClient.Status().Update(ctx, &ippool)).Should(Succeed())
 			ippool2 := v1alpha1.IPPool{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool2"}, &ippool2)).Should(Succeed())
 			ippool2.Status.Offset = constants.IPPoolOffsetFull
 			ippool2.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
-			ippool2.Status.AllocatedIPs["12.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypePod, ID: ns + "/" + pod2Name}
-			ippool2.Status.AllocatedIPs["12.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypeCNIUsed, ID: "dfgggg"}
-			ippool2.Status.AllocatedIPs["12.10.65.3"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocatedTypePod, ID: ns + "/" + "pod-unexist"}
+			ippool2.Status.AllocatedIPs["12.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + pod2Name}
+			ippool2.Status.AllocatedIPs["12.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeCNIUsed, ID: "dfgggg"}
+			ippool2.Status.AllocatedIPs["12.10.65.3"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + "pod-unexist"}
 			Expect(k8sClient.Status().Update(ctx, &ippool2)).Should(Succeed())
 		})
 		It("clean stale up", func() {

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -22,24 +22,24 @@ func TestGenAllocateInfo(t *testing.T) {
 		{
 			name: "type pod",
 			conf: NetConf{
-				Type:             v1alpha1.AllocatedTypePod,
+				Type:             v1alpha1.AllocateTypePod,
 				AllocateIdentify: "containerid",
 				K8sPodName:       "podname",
 				K8sPodNs:         "podns",
 			},
 			exp: v1alpha1.AllocateInfo{
-				Type: v1alpha1.AllocatedTypePod,
+				Type: v1alpha1.AllocateTypePod,
 				ID:   "podns/podname",
 			},
 		},
 		{
 			name: "type cniused",
 			conf: NetConf{
-				Type:             v1alpha1.AllocatedTypeCNIUsed,
+				Type:             v1alpha1.AllocateTypeCNIUsed,
 				AllocateIdentify: "identify",
 			},
 			exp: v1alpha1.AllocateInfo{
-				Type: v1alpha1.AllocatedTypeCNIUsed,
+				Type: v1alpha1.AllocateTypeCNIUsed,
 				ID:   "identify",
 			},
 		},
@@ -63,7 +63,7 @@ func TestReallocateIP(t *testing.T) {
 		{
 			name: "no reallocate for pod",
 			conf: NetConf{
-				Type:             v1alpha1.AllocatedTypePod,
+				Type:             v1alpha1.AllocateTypePod,
 				K8sPodName:       "podName",
 				K8sPodNs:         "podNs",
 				AllocateIdentify: "123556",
@@ -79,7 +79,7 @@ func TestReallocateIP(t *testing.T) {
 			name: "no reallocate for pool",
 			conf: NetConf{
 				Pool:       "pool1",
-				Type:       v1alpha1.AllocatedTypePod,
+				Type:       v1alpha1.AllocateTypePod,
 				K8sPodName: "podName",
 				K8sPodNs:   "podNs",
 			},
@@ -98,7 +98,7 @@ func TestReallocateIP(t *testing.T) {
 			conf: NetConf{
 				Pool:       "pool1",
 				IP:         "10.1.1.2",
-				Type:       v1alpha1.AllocatedTypePod,
+				Type:       v1alpha1.AllocateTypePod,
 				K8sPodName: "podName",
 				K8sPodNs:   "podNs",
 			},
@@ -115,7 +115,7 @@ func TestReallocateIP(t *testing.T) {
 		{
 			name: "no reallocate for cniused",
 			conf: NetConf{
-				Type:             v1alpha1.AllocatedTypeCNIUsed,
+				Type:             v1alpha1.AllocateTypeCNIUsed,
 				AllocateIdentify: "123456",
 				K8sPodName:       "podName",
 				K8sPodNs:         "podNs",
@@ -130,7 +130,7 @@ func TestReallocateIP(t *testing.T) {
 		{
 			name: "reallocate IP for pod",
 			conf: NetConf{
-				Type:       v1alpha1.AllocatedTypePod,
+				Type:       v1alpha1.AllocateTypePod,
 				K8sPodName: "podName",
 				K8sPodNs:   "podNs",
 			},
@@ -145,7 +145,7 @@ func TestReallocateIP(t *testing.T) {
 			name: "reallocate IP with pool",
 			conf: NetConf{
 				Pool:             "pool1",
-				Type:             v1alpha1.AllocatedTypeCNIUsed,
+				Type:             v1alpha1.AllocateTypeCNIUsed,
 				AllocateIdentify: "123455",
 				K8sPodName:       "podName",
 				K8sPodNs:         "podNs",
@@ -165,7 +165,7 @@ func TestReallocateIP(t *testing.T) {
 			conf: NetConf{
 				Pool:             "pool1",
 				IP:               "10.1.1.3",
-				Type:             v1alpha1.AllocatedTypeCNIUsed,
+				Type:             v1alpha1.AllocateTypeCNIUsed,
 				AllocateIdentify: "123455",
 				K8sPodName:       "podName",
 				K8sPodNs:         "podNs",
@@ -231,7 +231,7 @@ var _ = Describe("ipam", func() {
 			Context("ippool has enough IP", func() {
 				It("first allocate IP in ippool for type pod", func() {
 					c := NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: "pod1",
 						K8sPodNs:   "ns1",
 					}
@@ -246,7 +246,7 @@ var _ = Describe("ipam", func() {
 						g.Expect(ippool.Status.Offset).Should(Equal(int64(1)))
 						g.Expect(ippool.Status.UsedIps).Should(BeNil())
 						g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.0", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.0", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 					}, timeout, interval).Should(Succeed())
 				})
 				When("ippool has allocated some IP", func() {
@@ -261,7 +261,7 @@ var _ = Describe("ipam", func() {
 					})
 					It("allocate next IP for type cniused", func() {
 						c := NetConf{
-							Type:             v1alpha1.AllocatedTypeCNIUsed,
+							Type:             v1alpha1.AllocateTypeCNIUsed,
 							K8sPodName:       "pod1",
 							K8sPodNs:         "ns1",
 							AllocateIdentify: "identity",
@@ -277,8 +277,8 @@ var _ = Describe("ipam", func() {
 							g.Expect(ippool.Status.Offset).Should(Equal(int64(2)))
 							g.Expect(ippool.Status.UsedIps).Should(BeNil())
 							g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(2))
-							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.0", v1alpha1.AllocateInfo{ID: "ns-exist/pod-exist", Type: v1alpha1.AllocatedTypePod}))
-							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{ID: "identity", Type: v1alpha1.AllocatedTypeCNIUsed}))
+							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.0", v1alpha1.AllocateInfo{ID: "ns-exist/pod-exist", Type: v1alpha1.AllocateTypePod}))
+							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{ID: "identity", Type: v1alpha1.AllocateTypeCNIUsed}))
 						}, timeout, interval).Should(Succeed())
 					})
 				})
@@ -296,7 +296,7 @@ var _ = Describe("ipam", func() {
 
 					It("allocate valid IP", func() {
 						c := NetConf{
-							Type:       v1alpha1.AllocatedTypePod,
+							Type:       v1alpha1.AllocateTypePod,
 							K8sPodName: "pod1",
 							K8sPodNs:   "ns1",
 						}
@@ -312,8 +312,8 @@ var _ = Describe("ipam", func() {
 							g.Expect(len(ippool.Status.UsedIps)).Should(Equal(1))
 							g.Expect(ippool.Status.UsedIps).Should(HaveKeyWithValue("10.10.65.0", "containerID"))
 							g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(2))
-							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.2", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
-							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{ID: "ns-exist/pod-exist", Type: v1alpha1.AllocatedTypePod}))
+							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.2", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
+							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{ID: "ns-exist/pod-exist", Type: v1alpha1.AllocateTypePod}))
 						}, timeout, interval).Should(Succeed())
 					})
 				})
@@ -330,7 +330,7 @@ var _ = Describe("ipam", func() {
 				})
 				It("can't allocate IP", func() {
 					c := NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: "pod1",
 						K8sPodNs:   "ns1",
 					}
@@ -353,7 +353,7 @@ var _ = Describe("ipam", func() {
 				})
 				It("reallocate the same IP", func() {
 					c := NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: "pod-exist",
 						K8sPodNs:   "ns-exist",
 					}
@@ -369,7 +369,7 @@ var _ = Describe("ipam", func() {
 						g.Expect(len(ippool.Status.UsedIps)).Should(Equal(1))
 						g.Expect(ippool.Status.UsedIps).Should(HaveKeyWithValue("10.10.65.0", "containerID"))
 						g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{ID: "ns-exist/pod-exist", Type: v1alpha1.AllocatedTypePod}))
+						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{ID: "ns-exist/pod-exist", Type: v1alpha1.AllocateTypePod}))
 					}, timeout, interval).Should(Succeed())
 				})
 			})
@@ -381,7 +381,7 @@ var _ = Describe("ipam", func() {
 			})
 			It("skip subnet first IP", func() {
 				c := NetConf{
-					Type:       v1alpha1.AllocatedTypePod,
+					Type:       v1alpha1.AllocateTypePod,
 					K8sPodName: "pod1",
 					K8sPodNs:   "ns1",
 				}
@@ -396,7 +396,7 @@ var _ = Describe("ipam", func() {
 					g.Expect(ippool.Status.Offset).Should(Equal(int64(2)))
 					g.Expect(ippool.Status.UsedIps).Should(BeNil())
 					g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-					g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.1", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+					g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.1", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 				}, timeout, interval).Should(Succeed())
 			})
 			When("next IP is gateway", func() {
@@ -411,7 +411,7 @@ var _ = Describe("ipam", func() {
 				})
 				It("skip gateway", func() {
 					c := NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: "pod1",
 						K8sPodNs:   "ns1",
 					}
@@ -427,7 +427,7 @@ var _ = Describe("ipam", func() {
 						g.Expect(len(ippool.Status.UsedIps)).Should(Equal(1))
 						g.Expect(ippool.Status.UsedIps).Should(HaveKeyWithValue("12.10.64.1", "containerID"))
 						g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.3", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.3", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 					}, timeout, interval).Should(Succeed())
 				})
 			})
@@ -444,7 +444,7 @@ var _ = Describe("ipam", func() {
 				})
 				It("can't allocate IP", func() {
 					c := NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: "pod1",
 						K8sPodNs:   "ns1",
 					}
@@ -472,7 +472,7 @@ var _ = Describe("ipam", func() {
 				})
 				It("allocate from secondary pool", func() {
 					c := NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: "pod1",
 						K8sPodNs:   "ns1",
 					}
@@ -487,7 +487,7 @@ var _ = Describe("ipam", func() {
 						g.Expect(ippool.Status.Offset).Should(Equal(int64(2)))
 						g.Expect(ippool.Status.UsedIps).Should(BeNil())
 						g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.1", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.1", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 					}, timeout, interval).Should(Succeed())
 				})
 			})
@@ -495,7 +495,7 @@ var _ = Describe("ipam", func() {
 				It("allocate IP from specified pool", func() {
 					c := NetConf{
 						Pool:       "pool2",
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: "pod1",
 						K8sPodNs:   "ns1",
 					}
@@ -510,7 +510,7 @@ var _ = Describe("ipam", func() {
 						g.Expect(ippool.Status.Offset).Should(Equal(int64(2)))
 						g.Expect(ippool.Status.UsedIps).Should(BeNil())
 						g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.1", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.1", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 					}, timeout, interval).Should(Succeed())
 				})
 				When("a pod request IP in a second time", func() {
@@ -527,7 +527,7 @@ var _ = Describe("ipam", func() {
 						It("allocate new IP from specified pool", func() {
 							c := NetConf{
 								Pool:       "pool1",
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: "pod1",
 								K8sPodNs:   "ns1",
 							}
@@ -542,7 +542,7 @@ var _ = Describe("ipam", func() {
 								g.Expect(ippool.Status.Offset).Should(Equal(int64(1)))
 								g.Expect(ippool.Status.UsedIps).Should(BeNil())
 								g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.0", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.0", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 							}, timeout, interval).Should(Succeed())
 						})
 					})
@@ -550,7 +550,7 @@ var _ = Describe("ipam", func() {
 						It("reallocate the same IP", func() {
 							c := NetConf{
 								Pool:       "pool2",
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: "pod1",
 								K8sPodNs:   "ns1",
 							}
@@ -565,7 +565,7 @@ var _ = Describe("ipam", func() {
 								g.Expect(ippool.Status.Offset).Should(Equal(int64(4)))
 								g.Expect(ippool.Status.UsedIps).Should(BeNil())
 								g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.3", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.3", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 							}, timeout, interval).Should(Succeed())
 						})
 					})
@@ -574,7 +574,7 @@ var _ = Describe("ipam", func() {
 					It("can't allocate IP", func() {
 						c := NetConf{
 							Pool:       "pool-unexist",
-							Type:       v1alpha1.AllocatedTypePod,
+							Type:       v1alpha1.AllocateTypePod,
 							K8sPodName: "pod1",
 							K8sPodNs:   "ns1",
 						}
@@ -584,12 +584,12 @@ var _ = Describe("ipam", func() {
 					})
 				})
 			})
-			When("specify static IP", func() {
+			When("specify IP", func() {
 				It("allocate specified IP", func() {
 					c := NetConf{
 						Pool:       "pool1",
 						IP:         "10.10.65.3",
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: "pod1",
 						K8sPodNs:   "ns1",
 					}
@@ -604,10 +604,34 @@ var _ = Describe("ipam", func() {
 						g.Expect(ippool.Status.Offset).Should(Equal(int64(0)))
 						g.Expect(ippool.Status.UsedIps).Should(BeNil())
 						g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.3", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.3", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 					}, timeout, interval).Should(Succeed())
 				})
-				When("a pod request IP in a second time", func() {
+
+				It("allocate specified IP for type statefulset", func() {
+					c := NetConf{
+						Pool:       "pool1",
+						IP:         "10.10.65.3",
+						Type:       v1alpha1.AllocateTypeStatefulSet,
+						K8sPodName: "pod1",
+						K8sPodNs:   "ns1",
+						Owner:      "ns1/sts1",
+					}
+					res, err := ipam.ExecAdd(&c)
+					Expect(err).ToNot(HaveOccurred())
+					exp := makeCNIIPconfig("10.10.65.3", pool1mask, pool1GW)
+					Expect(*res.IPs[0]).To(Equal(*exp))
+					Eventually(func(g Gomega) {
+						ippool := v1alpha1.IPPool{}
+						g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &ippool)).Should(Succeed())
+						g.Expect(ippool.Status).ShouldNot(BeNil())
+						g.Expect(ippool.Status.Offset).Should(Equal(int64(0)))
+						g.Expect(ippool.Status.UsedIps).Should(BeNil())
+						g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
+						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.3", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypeStatefulSet, Owner: "ns1/sts1"}))
+					}, timeout, interval).Should(Succeed())
+				})
+				When("a pod request IP in a second time for type pod", func() {
 					BeforeEach(func() {
 						ippool := v1alpha1.IPPool{}
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool2"}, &ippool)).Should(Succeed())
@@ -622,7 +646,7 @@ var _ = Describe("ipam", func() {
 							c := NetConf{
 								Pool:       "pool2",
 								IP:         "12.10.64.6",
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: "pod1",
 								K8sPodNs:   "ns1",
 							}
@@ -637,8 +661,8 @@ var _ = Describe("ipam", func() {
 								g.Expect(ippool.Status.Offset).Should(Equal(int64(6)))
 								g.Expect(ippool.Status.UsedIps).Should(BeNil())
 								g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(2))
-								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.5", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
-								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.6", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.5", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
+								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.6", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 							}, timeout, interval).Should(Succeed())
 						})
 					})
@@ -647,7 +671,7 @@ var _ = Describe("ipam", func() {
 							c := NetConf{
 								Pool:       "pool2",
 								IP:         "12.10.64.5",
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: "pod1",
 								K8sPodNs:   "ns1",
 							}
@@ -662,9 +686,69 @@ var _ = Describe("ipam", func() {
 								g.Expect(ippool.Status.Offset).Should(Equal(int64(6)))
 								g.Expect(ippool.Status.UsedIps).Should(BeNil())
 								g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.5", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+								g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.5", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 							}, timeout, interval).Should(Succeed())
 						})
+					})
+				})
+				When("a pod request IP in a second time for type statefulset", func() {
+					BeforeEach(func() {
+						ippool := v1alpha1.IPPool{}
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool2"}, &ippool)).Should(Succeed())
+						ippool.Status = v1alpha1.IPPoolStatus{
+							Offset: 6,
+						}
+						ippool.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
+						ippool.Status.AllocatedIPs["12.10.64.5"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeStatefulSet, Owner: "ns1/sts1", ID: "ns1/pod1"}
+						Expect(k8sClient.Status().Update(ctx, &ippool)).Should(Succeed())
+					})
+					It("reallocate the same IP", func() {
+						c := NetConf{
+							Pool:       "pool2",
+							IP:         "12.10.64.5",
+							Type:       v1alpha1.AllocateTypeStatefulSet,
+							K8sPodName: "pod1",
+							K8sPodNs:   "ns1",
+							Owner:      "ns1/sts1",
+						}
+						res, err := ipam.ExecAdd(&c)
+						Expect(err).ToNot(HaveOccurred())
+						exp := makeCNIIPconfig("12.10.64.5", pool2mask, pool2GW)
+						Expect(*res.IPs[0]).To(Equal(*exp))
+						Eventually(func(g Gomega) {
+							ippool := v1alpha1.IPPool{}
+							g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool2"}, &ippool)).Should(Succeed())
+							g.Expect(ippool.Status).ShouldNot(BeNil())
+							g.Expect(ippool.Status.Offset).Should(Equal(int64(6)))
+							g.Expect(ippool.Status.UsedIps).Should(BeNil())
+							g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
+							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("12.10.64.5", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypeStatefulSet, Owner: "ns1/sts1"}))
+						}, timeout, interval).Should(Succeed())
+					})
+					It("can't reallocate IP for type different", func() {
+						c := NetConf{
+							Pool:       "pool2",
+							IP:         "12.10.64.5",
+							Type:       v1alpha1.AllocateTypePod,
+							K8sPodName: "pod1",
+							K8sPodNs:   "ns1",
+						}
+						_, err := ipam.ExecAdd(&c)
+						allocateInfo := v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypeStatefulSet, Owner: "ns1/sts1"}
+						Expect(err).Should(MatchError(fmt.Sprintf("static ip %s is already in use by %v", c.IP, allocateInfo)))
+					})
+					It("can't reallocate IP for owner different", func() {
+						c := NetConf{
+							Pool:       "pool2",
+							IP:         "12.10.64.5",
+							Type:       v1alpha1.AllocateTypeStatefulSet,
+							K8sPodName: "pod1",
+							K8sPodNs:   "ns1",
+							Owner:      "ns1/sts2",
+						}
+						_, err := ipam.ExecAdd(&c)
+						allocateInfo := v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypeStatefulSet, Owner: "ns1/sts1"}
+						Expect(err).Should(MatchError(fmt.Sprintf("static ip %s is already in use by %v", c.IP, allocateInfo)))
 					})
 				})
 				When("specified static IP has been used", func() {
@@ -681,7 +765,7 @@ var _ = Describe("ipam", func() {
 						c := NetConf{
 							Pool:       "pool2",
 							IP:         "12.10.64.5",
-							Type:       v1alpha1.AllocatedTypePod,
+							Type:       v1alpha1.AllocateTypePod,
 							K8sPodName: "pod1",
 							K8sPodNs:   "ns1",
 						}
@@ -704,14 +788,14 @@ var _ = Describe("ipam", func() {
 						c := NetConf{
 							Pool:       "pool2",
 							IP:         "12.10.64.5",
-							Type:       v1alpha1.AllocatedTypePod,
+							Type:       v1alpha1.AllocateTypePod,
 							K8sPodName: "pod1",
 							K8sPodNs:   "ns1",
 						}
 						res, err := ipam.ExecAdd(&c)
 						Expect(res).Should(BeNil())
 						Expect(err).Should(MatchError(fmt.Sprintf("static ip 12.10.64.5 is already in use by %v",
-							v1alpha1.AllocateInfo{ID: "ns-exist/pod-exist", Type: v1alpha1.AllocatedTypePod})))
+							v1alpha1.AllocateInfo{ID: "ns-exist/pod-exist", Type: v1alpha1.AllocateTypePod})))
 					})
 				})
 				When("specified static IP doesn't in pool", func() {
@@ -719,7 +803,7 @@ var _ = Describe("ipam", func() {
 						c := NetConf{
 							Pool:       "pool2",
 							IP:         "13.10.64.5",
-							Type:       v1alpha1.AllocatedTypePod,
+							Type:       v1alpha1.AllocateTypePod,
 							K8sPodName: "pod1",
 							K8sPodNs:   "ns1",
 						}
@@ -733,7 +817,7 @@ var _ = Describe("ipam", func() {
 						c := NetConf{
 							Pool:       "pool2",
 							IP:         "13.10.64",
-							Type:       v1alpha1.AllocatedTypePod,
+							Type:       v1alpha1.AllocateTypePod,
 							K8sPodName: "pod1",
 							K8sPodNs:   "ns1",
 						}
@@ -747,7 +831,7 @@ var _ = Describe("ipam", func() {
 						c := NetConf{
 							Pool:       "pool-unexist",
 							IP:         "12.10.64.5",
-							Type:       v1alpha1.AllocatedTypePod,
+							Type:       v1alpha1.AllocateTypePod,
 							K8sPodName: "pod1",
 							K8sPodNs:   "ns1",
 						}
@@ -775,7 +859,7 @@ var _ = Describe("ipam", func() {
 		})
 		It("release by usedIP", func() {
 			c := NetConf{
-				Type:             v1alpha1.AllocatedTypePod,
+				Type:             v1alpha1.AllocateTypePod,
 				AllocateIdentify: "containerID",
 				K8sPodName:       "pod-unexist",
 				K8sPodNs:         "ns-unexist",
@@ -793,7 +877,7 @@ var _ = Describe("ipam", func() {
 		When("release by allocate info", func() {
 			It("for type cniused", func() {
 				c := NetConf{
-					Type:             v1alpha1.AllocatedTypeCNIUsed,
+					Type:             v1alpha1.AllocateTypeCNIUsed,
 					AllocateIdentify: "cniusedID",
 				}
 				_ = ipam.ExecDel(&c)
@@ -804,31 +888,61 @@ var _ = Describe("ipam", func() {
 					g.Expect(ippool.Status.Offset).Should(Equal(int64(3)))
 					g.Expect(len(ippool.Status.UsedIps)).Should(Equal(1))
 					g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-					g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocatedTypePod}))
+					g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{ID: "ns1/pod1", Type: v1alpha1.AllocateTypePod}))
 				}, timeout, interval).Should(Succeed())
 			})
-			It("for type pod", func() {
-				c := NetConf{
-					Type:             v1alpha1.AllocatedTypePod,
-					AllocateIdentify: "cniusedID",
-					K8sPodName:       "pod1",
-					K8sPodNs:         "ns1",
-				}
-				_ = ipam.ExecDel(&c)
-				Eventually(func(g Gomega) {
-					ippool := v1alpha1.IPPool{}
-					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &ippool)).Should(Succeed())
-					g.Expect(ippool.Status).ShouldNot(BeNil())
-					g.Expect(ippool.Status.Offset).Should(Equal(int64(3)))
-					g.Expect(len(ippool.Status.UsedIps)).Should(Equal(1))
-					g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-					g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.3", v1alpha1.AllocateInfo{ID: "cniusedID", Type: v1alpha1.AllocatedTypeCNIUsed}))
-				}, timeout, interval).Should(Succeed())
+			When("for type pod", func() {
+				It("release for allocate type pod", func() {
+					c := NetConf{
+						Type:             v1alpha1.AllocateTypePod,
+						AllocateIdentify: "cniusedID",
+						K8sPodName:       "pod1",
+						K8sPodNs:         "ns1",
+					}
+					_ = ipam.ExecDel(&c)
+					Eventually(func(g Gomega) {
+						ippool := v1alpha1.IPPool{}
+						g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &ippool)).Should(Succeed())
+						g.Expect(ippool.Status).ShouldNot(BeNil())
+						g.Expect(ippool.Status.Offset).Should(Equal(int64(3)))
+						g.Expect(len(ippool.Status.UsedIps)).Should(Equal(1))
+						g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
+						g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.3", v1alpha1.AllocateInfo{ID: "cniusedID", Type: v1alpha1.AllocateTypeCNIUsed}))
+					}, timeout, interval).Should(Succeed())
+				})
+
+				When("for allocate type statefulset", func() {
+					BeforeEach(func() {
+						ippool := v1alpha1.IPPool{}
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &ippool)).Should(Succeed())
+						ippool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeStatefulSet, ID: "ns1/pod1", Owner: "ns1/sts1"}
+						Expect(k8sClient.Status().Update(ctx, &ippool)).Should(Succeed())
+					})
+					It("doesn't release", func() {
+						c := NetConf{
+							Type:             v1alpha1.AllocateTypePod,
+							AllocateIdentify: "cniusedID",
+							K8sPodName:       "pod1",
+							K8sPodNs:         "ns1",
+						}
+						_ = ipam.ExecDel(&c)
+						Eventually(func(g Gomega) {
+							ippool := v1alpha1.IPPool{}
+							g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &ippool)).Should(Succeed())
+							g.Expect(ippool.Status).ShouldNot(BeNil())
+							g.Expect(ippool.Status.Offset).Should(Equal(int64(3)))
+							g.Expect(len(ippool.Status.UsedIps)).Should(Equal(1))
+							g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(2))
+							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.1", v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeStatefulSet, ID: "ns1/pod1", Owner: "ns1/sts1"}))
+							g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.3", v1alpha1.AllocateInfo{ID: "cniusedID", Type: v1alpha1.AllocateTypeCNIUsed}))
+						}, timeout, interval).Should(Succeed())
+					})
+				})
 			})
 		})
 		It("release unexist", func() {
 			c := NetConf{
-				Type:       v1alpha1.AllocatedTypePod,
+				Type:       v1alpha1.AllocateTypePod,
 				K8sPodName: "pod-unexist",
 				K8sPodNs:   "ns-unexist",
 			}
@@ -856,7 +970,7 @@ var _ = Describe("ipam", func() {
 			})
 			It("release by usedIP and allocateinfo", func() {
 				c := NetConf{
-					Type:             v1alpha1.AllocatedTypePod,
+					Type:             v1alpha1.AllocateTypePod,
 					AllocateIdentify: "containerID",
 					K8sPodName:       "pod1",
 					K8sPodNs:         "ns1",
@@ -869,7 +983,7 @@ var _ = Describe("ipam", func() {
 					g.Expect(ippool.Status.Offset).Should(Equal(int64(3)))
 					g.Expect(len(ippool.Status.UsedIps)).Should(Equal(0))
 					g.Expect(len(ippool.Status.AllocatedIPs)).Should(Equal(1))
-					g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.3", v1alpha1.AllocateInfo{ID: "cniusedID", Type: v1alpha1.AllocatedTypeCNIUsed}))
+					g.Expect(ippool.Status.AllocatedIPs).Should(HaveKeyWithValue("10.10.65.3", v1alpha1.AllocateInfo{ID: "cniusedID", Type: v1alpha1.AllocateTypeCNIUsed}))
 
 					ippool = v1alpha1.IPPool{}
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool2"}, &ippool)).Should(Succeed())

--- a/pkg/ipam/net_conf.go
+++ b/pkg/ipam/net_conf.go
@@ -3,7 +3,10 @@ package ipam
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -21,14 +24,15 @@ type NetConf struct {
 	AllocateIdentify string
 	K8sPodName       string
 	K8sPodNs         string
+	Owner            string
 	// default is allocate IP to Pod
 	Type v1alpha1.AllocateType
 }
 
-// Complete add ippool and static ip info to NetConf, param k8sClient must add corev1 scheme
-func (c *NetConf) Complete(ctx context.Context, k8sClient client.Client) error {
+// Complete add ippool and static ip info to NetConf, param k8sClient must add corev1 scheme and appsv1 scheme
+func (c *NetConf) Complete(ctx context.Context, k8sClient client.Client, poolNs string) error {
 	// only complete netconf by k8s annotation
-	if c.Type != v1alpha1.AllocatedTypePod {
+	if c.Type != v1alpha1.AllocateTypePod {
 		return nil
 	}
 	// has been specify pool, return
@@ -37,10 +41,11 @@ func (c *NetConf) Complete(ctx context.Context, k8sClient client.Client) error {
 	}
 
 	if c.K8sPodNs == "" || c.K8sPodName == "" {
-		klog.Errorf("netconf %v must set K8sPodNs and K8sPodName for type %s", *c, v1alpha1.AllocatedTypePod)
-		return fmt.Errorf("must set K8sPodNs and K8sPodName for type %s", v1alpha1.AllocatedTypePod)
+		klog.Errorf("netconf %v must set K8sPodNs and K8sPodName for type %s", *c, v1alpha1.AllocateTypePod)
+		return fmt.Errorf("must set K8sPodNs and K8sPodName for type %s", v1alpha1.AllocateTypePod)
 	}
 
+	// complete by pod
 	pod := corev1.Pod{}
 	podNsName := types.NamespacedName{Namespace: c.K8sPodNs, Name: c.K8sPodName}
 	err := k8sClient.Get(ctx, podNsName, &pod)
@@ -58,19 +63,45 @@ func (c *NetConf) Complete(ctx context.Context, k8sClient client.Client) error {
 		}
 		c.IP = ip
 	}
+	if c.Pool != "" {
+		return nil
+	}
+
+	// complete by statefulset
+	if len(pod.OwnerReferences) > 0 {
+		for i := range pod.OwnerReferences {
+			if pod.OwnerReferences[i].Kind == constants.KindStatefulSet {
+				if err := c.completeByStatefulSet(ctx, k8sClient, pod.OwnerReferences[i].Name, poolNs); err != nil {
+					klog.Errorf("Failed to get pod %v specified ip or pool from statefulset, err: %v", podNsName, err)
+					return err
+				}
+				return nil
+			}
+		}
+	}
+
 	return nil
 }
 
 func (c *NetConf) Valid() error {
-	if c.Type == v1alpha1.AllocatedTypeCNIUsed {
+	if c.Type == v1alpha1.AllocateTypeCNIUsed {
 		if c.AllocateIdentify == "" {
-			return fmt.Errorf("type %s must set AllocatedIdentify", v1alpha1.AllocatedTypeCNIUsed)
+			return fmt.Errorf("type %s must set AllocatedIdentify", v1alpha1.AllocateTypeCNIUsed)
 		}
 	}
 
-	if c.Type == v1alpha1.AllocatedTypePod {
+	if c.Type == v1alpha1.AllocateTypePod || c.Type == v1alpha1.AllocateTypeStatefulSet {
 		if c.K8sPodName == "" || c.K8sPodNs == "" {
-			return fmt.Errorf("type %s must set K8sPodNs and K8sPodName", v1alpha1.AllocatedTypePod)
+			return fmt.Errorf("type %s must set K8sPodNs and K8sPodName", c.Type)
+		}
+	}
+
+	if c.Type == v1alpha1.AllocateTypeStatefulSet {
+		if c.Owner == "" {
+			return fmt.Errorf("type %s must set Owner", c.Type)
+		}
+		if c.Pool == "" || c.IP == "" {
+			return fmt.Errorf("type %s must set Pool and IP", c.Type)
 		}
 	}
 
@@ -79,15 +110,96 @@ func (c *NetConf) Valid() error {
 
 func (c *NetConf) getAllocateID() string {
 	allocatedID := c.AllocateIdentify
-	if c.Type == v1alpha1.AllocatedTypePod {
-		allocatedID = utils.GetAllocateIDFromPod(c.K8sPodNs, c.K8sPodName)
+	if c.Type == v1alpha1.AllocateTypePod || c.Type == v1alpha1.AllocateTypeStatefulSet {
+		allocatedID = utils.GenAllocateIDFromPod(c.K8sPodNs, c.K8sPodName)
 	}
 	return allocatedID
 }
 
 func (c *NetConf) genAllocateInfo() v1alpha1.AllocateInfo {
 	return v1alpha1.AllocateInfo{
-		Type: c.Type,
-		ID:   c.getAllocateID(),
+		Type:  c.Type,
+		ID:    c.getAllocateID(),
+		Owner: c.Owner,
 	}
+}
+
+func (c *NetConf) podStr() string {
+	return c.K8sPodNs + "/" + c.K8sPodName
+}
+
+func (c *NetConf) completeByStatefulSet(ctx context.Context, k8sClient client.Client, stsName string, poolNs string) error {
+	sts := appsv1.StatefulSet{}
+	stsNsName := types.NamespacedName{Namespace: c.K8sPodNs, Name: stsName}
+	err := k8sClient.Get(ctx, stsNsName, &sts)
+	if err != nil {
+		klog.Errorf("Failed to get statefulset %v, err: %v", stsNsName, err)
+		return err
+	}
+	if pool, ok := sts.Annotations[constants.IpamAnnotationPool]; ok {
+		c.Pool = pool
+	}
+
+	var ipList []string
+	if ips, ok := sts.Annotations[constants.IpamAnnotationIPList]; ok {
+		if c.Pool == "" {
+			klog.Errorf("statefulset %v can't only specify IP list but no pool", sts)
+			return fmt.Errorf("can't only specify IP list but no pool")
+		}
+		ipList = strings.Split(ips, ",")
+	} else {
+		return nil
+	}
+
+	c.Type = v1alpha1.AllocateTypeStatefulSet
+	c.Owner = utils.GenOwner(sts.GetNamespace(), sts.GetName())
+
+	pool := v1alpha1.IPPool{}
+	poolNsName := types.NamespacedName{Namespace: poolNs, Name: c.Pool}
+	if err := k8sClient.Get(ctx, poolNsName, &pool); err != nil {
+		klog.Errorf("Failed to get specified ippool %v by pod %s owner statefulset %v, err: %v", poolNsName, c.podStr(), stsNsName, err)
+		return err
+	}
+	_, ipNet, _ := net.ParseCIDR(pool.Spec.CIDR)
+	unUsedIPs := []string{}
+	for _, ipStr := range ipList {
+		ip := net.ParseIP(ipStr)
+		// check if valid
+		if ip == nil {
+			klog.Errorf("Invalid ip %s", ipStr)
+			continue
+		}
+		if !ipNet.Contains(ip) {
+			klog.Errorf("IP %s doesn't in specified pool %v", ipStr, pool)
+			continue
+		}
+		if _, exist := pool.Status.UsedIps[ipStr]; exist {
+			continue
+		}
+		if allocateInfo, exist := pool.Status.AllocatedIPs[ipStr]; exist {
+			if allocateInfo.Type == v1alpha1.AllocateTypeStatefulSet && allocateInfo.ID == c.getAllocateID() && allocateInfo.Owner == c.Owner {
+				c.IP = ipStr
+				return nil
+			}
+			continue
+		}
+
+		unUsedIPs = append(unUsedIPs, ipStr)
+	}
+
+	if len(unUsedIPs) > 0 {
+		if pool.Status.AllocatedIPs == nil {
+			pool.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
+		}
+		pool.Status.AllocatedIPs[unUsedIPs[0]] = c.genAllocateInfo()
+		if err := k8sClient.Status().Update(ctx, &pool); err != nil {
+			klog.Errorf("Failed to update ippool %v status for allocate %s to pod %s, err: %v", poolNsName, unUsedIPs[0], c.podStr(), err)
+			return err
+		}
+		c.IP = unUsedIPs[0]
+		return nil
+	}
+
+	klog.Errorf("For statefulset %v ipList %v, no valid or unallocate ip in pool %v to allocate to pod %s", stsNsName, ipList, poolNsName, c.podStr())
+	return fmt.Errorf("no valid or unallocate ip in statefulset %v ip list %v", stsNsName, ipList)
 }

--- a/pkg/ipam/net_conf_test.go
+++ b/pkg/ipam/net_conf_test.go
@@ -6,8 +6,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/everoute/ipam/api/ipam/v1alpha1"
@@ -16,10 +18,13 @@ import (
 
 var _ = Describe("net_conf_complete", func() {
 	podname := "pod1"
+	podLabel := make(map[string]string)
+	podLabel["owner"] = "sts-sts1"
 	pod1 := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podname,
 			Namespace: ns,
+			Labels:    podLabel,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -30,8 +35,21 @@ var _ = Describe("net_conf_complete", func() {
 			},
 		},
 	}
+	pool1 := v1alpha1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pool1",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.IPPoolSpec{
+			CIDR:    "10.10.65.0/29",
+			Subnet:  "10.10.64.0/20",
+			Gateway: "10.10.64.1",
+		},
+	}
 	AfterEach(func() {
 		Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(ns))).Should(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &appsv1.StatefulSet{}, client.InNamespace(ns))).Should(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &v1alpha1.IPPool{}, client.InNamespace(ns))).Should(Succeed())
 	})
 
 	Context("type cniused", func() {
@@ -48,14 +66,14 @@ var _ = Describe("net_conf_complete", func() {
 					var c *NetConf
 					BeforeEach(func() {
 						c = &NetConf{
-							Type:       v1alpha1.AllocatedTypeCNIUsed,
+							Type:       v1alpha1.AllocateTypeCNIUsed,
 							K8sPodName: podname,
 							K8sPodNs:   ns,
 							Pool:       "pool2",
 						}
 					})
 					It("ip and pool doesn't changed by k8sinfo", func() {
-						Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+						Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 						Expect(c.Pool).Should(Equal("pool2"))
 						Expect(c.IP).Should(Equal(""))
 					})
@@ -64,13 +82,13 @@ var _ = Describe("net_conf_complete", func() {
 					var c *NetConf
 					BeforeEach(func() {
 						c = &NetConf{
-							Type:       v1alpha1.AllocatedTypeCNIUsed,
+							Type:       v1alpha1.AllocateTypeCNIUsed,
 							K8sPodName: podname,
 							K8sPodNs:   ns,
 						}
 					})
 					It("shouldn't set ip and pool by k8sinfo", func() {
-						Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+						Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 						Expect(c.Pool).Should(Equal(""))
 						Expect(c.IP).Should(Equal(""))
 					})
@@ -91,14 +109,14 @@ var _ = Describe("net_conf_complete", func() {
 				var c *NetConf
 				BeforeEach(func() {
 					c = &NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: podname,
 						K8sPodNs:   ns,
 						Pool:       "pool2",
 					}
 				})
 				It("netconf pool doesn't changed by k8sinfo", func() {
-					Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 					Expect(c.Pool).Should(Equal("pool2"))
 					Expect(c.IP).Should(Equal(""))
 				})
@@ -107,7 +125,7 @@ var _ = Describe("net_conf_complete", func() {
 				var c *NetConf
 				BeforeEach(func() {
 					c = &NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: podname,
 						K8sPodNs:   ns,
 						Pool:       "pool2",
@@ -115,7 +133,7 @@ var _ = Describe("net_conf_complete", func() {
 					}
 				})
 				It("netconf pool and ip doesn't changed by k8sinfo", func() {
-					Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 					Expect(c.Pool).Should(Equal("pool2"))
 					Expect(c.IP).Should(Equal("10.10.10.2"))
 				})
@@ -125,13 +143,13 @@ var _ = Describe("net_conf_complete", func() {
 					var c *NetConf
 					BeforeEach(func() {
 						c = &NetConf{
-							Type:       v1alpha1.AllocatedTypePod,
+							Type:       v1alpha1.AllocateTypePod,
 							K8sPodName: podname,
 							K8sPodNs:   ns,
 						}
 					})
 					It("netconf will set pool by k8sinfo", func() {
-						Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+						Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 						Expect(c.Pool).Should(Equal("pool1"))
 						Expect(c.IP).Should(Equal(""))
 					})
@@ -140,12 +158,12 @@ var _ = Describe("net_conf_complete", func() {
 					var c *NetConf
 					BeforeEach(func() {
 						c = &NetConf{
-							Type: v1alpha1.AllocatedTypePod,
+							Type: v1alpha1.AllocateTypePod,
 						}
 					})
 					It("error for netconf is invalid", func() {
-						err := c.Complete(ctx, k8sClient)
-						Expect(err).Should(MatchError(fmt.Sprintf("must set K8sPodNs and K8sPodName for type %s", v1alpha1.AllocatedTypePod)))
+						err := c.Complete(ctx, k8sClient, ns)
+						Expect(err).Should(MatchError(fmt.Sprintf("must set K8sPodNs and K8sPodName for type %s", v1alpha1.AllocateTypePod)))
 						Expect(c.Pool).Should(Equal(""))
 						Expect(c.IP).Should(Equal(""))
 					})
@@ -166,14 +184,14 @@ var _ = Describe("net_conf_complete", func() {
 						var c *NetConf
 						BeforeEach(func() {
 							c = &NetConf{
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: podname,
 								K8sPodNs:   ns,
 								Pool:       "pool2",
 							}
 						})
 						It("netconf pool and ip doesn't changed by k8sinfo", func() {
-							Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+							Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 							Expect(c.Pool).Should(Equal("pool2"))
 							Expect(c.IP).Should(Equal(""))
 						})
@@ -182,14 +200,14 @@ var _ = Describe("net_conf_complete", func() {
 						var c *NetConf
 						BeforeEach(func() {
 							c = &NetConf{
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: podname,
 								K8sPodNs:   ns,
 								Pool:       "pool1",
 							}
 						})
 						It("netconf doesn't set ip by k8sinfo", func() {
-							Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+							Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 							Expect(c.Pool).Should(Equal("pool1"))
 							Expect(c.IP).Should(Equal(""))
 						})
@@ -200,7 +218,7 @@ var _ = Describe("net_conf_complete", func() {
 						var c *NetConf
 						BeforeEach(func() {
 							c = &NetConf{
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: podname,
 								K8sPodNs:   ns,
 								Pool:       "pool2",
@@ -208,7 +226,7 @@ var _ = Describe("net_conf_complete", func() {
 							}
 						})
 						It("netconf pool and ip doesn't changed by k8sinfo", func() {
-							Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+							Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 							Expect(c.Pool).Should(Equal("pool2"))
 							Expect(c.IP).Should(Equal("10.10.10.2"))
 						})
@@ -217,7 +235,7 @@ var _ = Describe("net_conf_complete", func() {
 						var c *NetConf
 						BeforeEach(func() {
 							c = &NetConf{
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: podname,
 								K8sPodNs:   ns,
 								Pool:       "pool1",
@@ -225,7 +243,7 @@ var _ = Describe("net_conf_complete", func() {
 							}
 						})
 						It("netconf ip doesn't changed by k8sinfo", func() {
-							Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+							Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 							Expect(c.Pool).Should(Equal("pool1"))
 							Expect(c.IP).Should(Equal("10.10.10.2"))
 						})
@@ -236,12 +254,12 @@ var _ = Describe("net_conf_complete", func() {
 						var c *NetConf
 						BeforeEach(func() {
 							c = &NetConf{
-								Type: v1alpha1.AllocatedTypePod,
+								Type: v1alpha1.AllocateTypePod,
 							}
 						})
 						It("error for netconf is invalid", func() {
-							err := c.Complete(ctx, k8sClient)
-							Expect(err).Should(MatchError(fmt.Sprintf("must set K8sPodNs and K8sPodName for type %s", v1alpha1.AllocatedTypePod)))
+							err := c.Complete(ctx, k8sClient, ns)
+							Expect(err).Should(MatchError(fmt.Sprintf("must set K8sPodNs and K8sPodName for type %s", v1alpha1.AllocateTypePod)))
 							Expect(c.Pool).Should(Equal(""))
 							Expect(c.IP).Should(Equal(""))
 						})
@@ -250,13 +268,13 @@ var _ = Describe("net_conf_complete", func() {
 						var c *NetConf
 						BeforeEach(func() {
 							c = &NetConf{
-								Type:       v1alpha1.AllocatedTypePod,
+								Type:       v1alpha1.AllocateTypePod,
 								K8sPodName: podname,
 								K8sPodNs:   ns,
 							}
 						})
 						It("netconf will set pool and ip by k8sinfo", func() {
-							Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+							Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 							Expect(c.Pool).Should(Equal("pool1"))
 							Expect(c.IP).Should(Equal("10.10.10.1"))
 						})
@@ -272,11 +290,11 @@ var _ = Describe("net_conf_complete", func() {
 				})
 				It("error for pod annotation only set ip", func() {
 					c := &NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: podname,
 						K8sPodNs:   ns,
 					}
-					err := c.Complete(ctx, k8sClient)
+					err := c.Complete(ctx, k8sClient, ns)
 					Expect(err).Should(MatchError("can't only specify static IP but no pool"))
 				})
 			})
@@ -290,14 +308,14 @@ var _ = Describe("net_conf_complete", func() {
 				var c *NetConf
 				BeforeEach(func() {
 					c = &NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: podname,
 						K8sPodNs:   ns,
 						Pool:       "pool2",
 					}
 				})
 				It("netconf doesn't changed", func() {
-					Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 					Expect(c.Pool).Should(Equal("pool2"))
 					Expect(c.IP).Should(Equal(""))
 				})
@@ -306,13 +324,13 @@ var _ = Describe("net_conf_complete", func() {
 				var c *NetConf
 				BeforeEach(func() {
 					c = &NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: podname,
 						K8sPodNs:   ns,
 					}
 				})
 				It("netconf doesn't changed", func() {
-					Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 					Expect(c.Pool).Should(Equal(""))
 					Expect(c.IP).Should(Equal(""))
 				})
@@ -323,14 +341,14 @@ var _ = Describe("net_conf_complete", func() {
 				var c *NetConf
 				BeforeEach(func() {
 					c = &NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: podname,
 						K8sPodNs:   ns,
 						Pool:       "pool2",
 					}
 				})
 				It("netconf doesn't changed", func() {
-					Expect(c.Complete(ctx, k8sClient)).Should(Succeed())
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
 					Expect(c.Pool).Should(Equal("pool2"))
 					Expect(c.IP).Should(Equal(""))
 				})
@@ -339,17 +357,305 @@ var _ = Describe("net_conf_complete", func() {
 				var c *NetConf
 				BeforeEach(func() {
 					c = &NetConf{
-						Type:       v1alpha1.AllocatedTypePod,
+						Type:       v1alpha1.AllocateTypePod,
 						K8sPodName: podname,
 						K8sPodNs:   ns,
 					}
 				})
 				It("error for can't find pod", func() {
-					err := c.Complete(ctx, k8sClient)
+					err := c.Complete(ctx, k8sClient, ns)
 					Expect(err).ShouldNot(BeNil())
 					Expect(c.Pool).Should(Equal(""))
 					Expect(c.IP).Should(Equal(""))
 				})
+			})
+		})
+	})
+
+	Context("type statefulset", func() {
+		stsName := "sts1"
+		sts1 := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      stsName,
+				Namespace: ns,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: podLabel,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: podLabel,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test",
+								Image: "network",
+							},
+						},
+					},
+				},
+			},
+		}
+		Context("statefulset specify ippool", func() {
+			BeforeEach(func() {
+				sts := sts1.DeepCopy()
+				sts.Annotations = make(map[string]string, 1)
+				sts.Annotations[constants.IpamAnnotationPool] = "pool1"
+				Expect(k8sClient.Create(ctx, sts)).Should(Succeed())
+				pod := pod1.DeepCopy()
+				pod.OwnerReferences = make([]metav1.OwnerReference, 1)
+				pod.OwnerReferences[0] = metav1.OwnerReference{Kind: constants.KindStatefulSet, Name: stsName, UID: sts.GetUID(), APIVersion: "apps/v1"}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+			})
+			When("pod specify another ippool", func() {
+				BeforeEach(func() {
+					pod := corev1.Pod{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: podname}, &pod)).Should(Succeed())
+					pod.Annotations = make(map[string]string, 1)
+					pod.Annotations[constants.IpamAnnotationPool] = "pool2"
+					Expect(k8sClient.Update(ctx, &pod)).Should(Succeed())
+				})
+				It("netconf set ippool specified by pod", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
+					Expect(c.Type).Should(Equal(v1alpha1.AllocateTypePod))
+					Expect(c.Pool).Should(Equal("pool2"))
+				})
+			})
+			It("netconf set ipool specified by statefulset", func() {
+				c := NetConf{
+					K8sPodName: podname,
+					K8sPodNs:   ns,
+					Type:       v1alpha1.AllocateTypePod,
+				}
+				Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
+				Expect(c.Type).Should(Equal(v1alpha1.AllocateTypePod))
+				Expect(c.Pool).Should(Equal("pool1"))
+				Expect(c.Owner).Should(Equal(""))
+			})
+		})
+		Context("statefulset specify ip-list", func() {
+			BeforeEach(func() {
+				pool := pool1.DeepCopy()
+				Expect(k8sClient.Create(ctx, pool)).Should(Succeed())
+				sts := sts1.DeepCopy()
+				sts.Annotations = make(map[string]string, 2)
+				sts.Annotations[constants.IpamAnnotationPool] = "pool1"
+				sts.Annotations[constants.IpamAnnotationIPList] = "10.10.65.1,10.10.65.2"
+				Expect(k8sClient.Create(ctx, sts)).Should(Succeed())
+				pod := pod1.DeepCopy()
+				pod.OwnerReferences = make([]metav1.OwnerReference, 1)
+				pod.OwnerReferences[0] = metav1.OwnerReference{Kind: constants.KindStatefulSet, Name: stsName, UID: sts.GetUID(), APIVersion: "apps/v1"}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+			})
+			When("pod specify static IP", func() {
+				BeforeEach(func() {
+					pod := corev1.Pod{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: podname}, &pod)).Should(Succeed())
+					pod.Annotations = make(map[string]string, 2)
+					pod.Annotations[constants.IpamAnnotationPool] = "pool1"
+					pod.Annotations[constants.IpamAnnotationStaticIP] = "10.10.65.3"
+					Expect(k8sClient.Update(ctx, &pod)).Should(Succeed())
+				})
+				It("netconf set ip specified by pod static IP", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
+					Expect(c.Type).Should(Equal(v1alpha1.AllocateTypePod))
+					Expect(c.Pool).Should(Equal("pool1"))
+					Expect(c.IP).Should(Equal("10.10.65.3"))
+					Expect(c.Owner).Should(Equal(""))
+				})
+			})
+			When("ip-list is not in ippool", func() {
+				BeforeEach(func() {
+					sts := appsv1.StatefulSet{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: stsName}, &sts)).Should(Succeed())
+					sts.Annotations[constants.IpamAnnotationIPList] = "12.10.65.1"
+					Expect(k8sClient.Update(ctx, &sts)).Should(Succeed())
+				})
+				It("netconf set ip failed", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					err := c.Complete(ctx, k8sClient, ns)
+					stsNsName := types.NamespacedName{Namespace: ns, Name: stsName}
+					ipList := []string{"12.10.65.1"}
+					Expect(err).Should(MatchError(fmt.Sprintf("no valid or unallocate ip in statefulset %v ip list %v", stsNsName, ipList)))
+				})
+			})
+			When("ip-list is empty string", func() {
+				BeforeEach(func() {
+					sts := appsv1.StatefulSet{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: stsName}, &sts)).Should(Succeed())
+					sts.Annotations[constants.IpamAnnotationIPList] = ""
+					Expect(k8sClient.Update(ctx, &sts)).Should(Succeed())
+				})
+
+				It("netconf set ip failed", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					err := c.Complete(ctx, k8sClient, ns)
+					stsNsName := types.NamespacedName{Namespace: ns, Name: stsName}
+					ipList := []string{""}
+					Expect(err).Should(MatchError(fmt.Sprintf("no valid or unallocate ip in statefulset %v ip list %v", stsNsName, ipList)))
+				})
+			})
+			When("ip-list is invalid ip", func() {
+				BeforeEach(func() {
+					sts := appsv1.StatefulSet{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: stsName}, &sts)).Should(Succeed())
+					sts.Annotations[constants.IpamAnnotationIPList] = "10.1.2,10.3.4"
+					Expect(k8sClient.Update(ctx, &sts)).Should(Succeed())
+				})
+
+				It("netconf set ip failed", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					err := c.Complete(ctx, k8sClient, ns)
+					stsNsName := types.NamespacedName{Namespace: ns, Name: stsName}
+					ipList := []string{"10.1.2", "10.3.4"}
+					Expect(err).Should(MatchError(fmt.Sprintf("no valid or unallocate ip in statefulset %v ip list %v", stsNsName, ipList)))
+				})
+			})
+			When("ip-list has been allocated", func() {
+				BeforeEach(func() {
+					pool := v1alpha1.IPPool{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &pool)).Should(Succeed())
+					pool.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
+					pool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeCNIUsed, ID: "cniusedid"}
+					pool.Status.AllocatedIPs["10.10.65.2"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: "ns-unexist/pod-unexist"}
+					pool.Status.AllocatedIPs["10.10.65.4"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypePod, ID: ns + "/" + podname}
+					pool.Status.UsedIps = make(map[string]string)
+					pool.Status.UsedIps["10.10.65.3"] = "containerid"
+					Expect(k8sClient.Status().Update(ctx, &pool)).Should(Succeed())
+
+					sts := appsv1.StatefulSet{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: stsName}, &sts)).Should(Succeed())
+					sts.Annotations[constants.IpamAnnotationIPList] = "10.10.65.1,10.10.65.2,10.10.65.3,10.10.65.4"
+					Expect(k8sClient.Update(ctx, &sts)).Should(Succeed())
+				})
+				It("netconf set ip failed", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					err := c.Complete(ctx, k8sClient, ns)
+					stsNsName := types.NamespacedName{Namespace: ns, Name: stsName}
+					ipList := []string{"10.10.65.1", "10.10.65.2", "10.10.65.3", "10.10.65.4"}
+					Expect(err).Should(MatchError(fmt.Sprintf("no valid or unallocate ip in statefulset %v ip list %v", stsNsName, ipList)))
+				})
+			})
+			When("first allocate ip from ip-list", func() {
+				BeforeEach(func() {
+					sts := appsv1.StatefulSet{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: stsName}, &sts)).Should(Succeed())
+					sts.Annotations[constants.IpamAnnotationIPList] = "10.10.65.1,10.10.65.2,10.10.65.3,10.10.65.4"
+					Expect(k8sClient.Update(ctx, &sts)).Should(Succeed())
+				})
+				It("netconf set ip from ip-list", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
+					Expect(c.Type).Should(Equal(v1alpha1.AllocateTypeStatefulSet))
+					Expect(c.Pool).Should(Equal("pool1"))
+					Expect(c.IP).Should(Equal("10.10.65.1"))
+					Expect(c.Owner).Should(Equal(ns + "/" + stsName))
+				})
+			})
+			When("allocate ip from ip-list", func() {
+				BeforeEach(func() {
+					pool := v1alpha1.IPPool{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &pool)).Should(Succeed())
+					pool.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
+					pool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeCNIUsed, ID: "cniusedid"}
+					pool.Status.UsedIps = make(map[string]string)
+					pool.Status.UsedIps["10.10.65.3"] = "containerid"
+					Expect(k8sClient.Status().Update(ctx, &pool)).Should(Succeed())
+
+					sts := appsv1.StatefulSet{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: stsName}, &sts)).Should(Succeed())
+					sts.Annotations[constants.IpamAnnotationIPList] = "10.10.65.1,10.10.65.2,10.10.65.3,10.10.65.4"
+					Expect(k8sClient.Update(ctx, &sts)).Should(Succeed())
+				})
+				It("netconf set ip from ip-list", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
+					Expect(c.Type).Should(Equal(v1alpha1.AllocateTypeStatefulSet))
+					Expect(c.Pool).Should(Equal("pool1"))
+					Expect(c.IP).Should(Equal("10.10.65.2"))
+					Expect(c.Owner).Should(Equal(ns + "/" + stsName))
+				})
+			})
+			When("reallocate ip from ip-list", func() {
+				BeforeEach(func() {
+					pool := v1alpha1.IPPool{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "pool1"}, &pool)).Should(Succeed())
+					pool.Status.AllocatedIPs = make(map[string]v1alpha1.AllocateInfo)
+					pool.Status.AllocatedIPs["10.10.65.1"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeCNIUsed, ID: "cniusedid"}
+					pool.Status.AllocatedIPs["10.10.65.4"] = v1alpha1.AllocateInfo{Type: v1alpha1.AllocateTypeStatefulSet, ID: ns + "/" + podname, Owner: ns + "/" + stsName}
+					pool.Status.UsedIps = make(map[string]string)
+					pool.Status.UsedIps["10.10.65.3"] = "containerid"
+					Expect(k8sClient.Status().Update(ctx, &pool)).Should(Succeed())
+
+					sts := appsv1.StatefulSet{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: stsName}, &sts)).Should(Succeed())
+					sts.Annotations[constants.IpamAnnotationIPList] = "10.10.65.1,10.10.65.2,10.10.65.3,10.10.65.4"
+					Expect(k8sClient.Update(ctx, &sts)).Should(Succeed())
+				})
+				It("netconf set same ip for pod reconfigure", func() {
+					c := NetConf{
+						K8sPodName: podname,
+						K8sPodNs:   ns,
+						Type:       v1alpha1.AllocateTypePod,
+					}
+					Expect(c.Complete(ctx, k8sClient, ns)).Should(Succeed())
+					Expect(c.Type).Should(Equal(v1alpha1.AllocateTypeStatefulSet))
+					Expect(c.Pool).Should(Equal("pool1"))
+					Expect(c.IP).Should(Equal("10.10.65.4"))
+					Expect(c.Owner).Should(Equal(ns + "/" + stsName))
+				})
+			})
+		})
+		Context("pod owner statefulset doesn't exist", func() {
+			BeforeEach(func() {
+				pod := pod1.DeepCopy()
+				pod.OwnerReferences = make([]metav1.OwnerReference, 1)
+				pod.OwnerReferences[0] = metav1.OwnerReference{Kind: constants.KindStatefulSet, Name: stsName, UID: "123456", APIVersion: "apps/v1"}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+			})
+			It("netconf failed set ip and ippool", func() {
+				c := NetConf{
+					K8sPodName: podname,
+					K8sPodNs:   ns,
+					Type:       v1alpha1.AllocateTypePod,
+				}
+				Expect(c.Complete(ctx, k8sClient, ns)).ShouldNot(BeNil())
 			})
 		})
 	})
@@ -364,7 +670,7 @@ func TestValid(t *testing.T) {
 		{
 			name: "valid netconf for type cniused",
 			c: NetConf{
-				Type:             v1alpha1.AllocatedTypeCNIUsed,
+				Type:             v1alpha1.AllocateTypeCNIUsed,
 				AllocateIdentify: "cniusedid",
 			},
 			isValid: true,
@@ -372,7 +678,7 @@ func TestValid(t *testing.T) {
 		{
 			name: "valid for type pod with containerid",
 			c: NetConf{
-				Type:             v1alpha1.AllocatedTypePod,
+				Type:             v1alpha1.AllocateTypePod,
 				AllocateIdentify: "containerid",
 				K8sPodName:       "pod",
 				K8sPodNs:         "ns",
@@ -382,7 +688,7 @@ func TestValid(t *testing.T) {
 		{
 			name: "valid with pool",
 			c: NetConf{
-				Type:             v1alpha1.AllocatedTypePod,
+				Type:             v1alpha1.AllocateTypePod,
 				AllocateIdentify: "containerid",
 				K8sPodName:       "pod",
 				K8sPodNs:         "ns",
@@ -393,7 +699,7 @@ func TestValid(t *testing.T) {
 		{
 			name: "valid with ip",
 			c: NetConf{
-				Type:       v1alpha1.AllocatedTypePod,
+				Type:       v1alpha1.AllocateTypePod,
 				K8sPodName: "pod",
 				K8sPodNs:   "ns",
 				Pool:       "pool",
@@ -404,7 +710,7 @@ func TestValid(t *testing.T) {
 		{
 			name: "no k8sPodName for type pod",
 			c: NetConf{
-				Type:             v1alpha1.AllocatedTypePod,
+				Type:             v1alpha1.AllocateTypePod,
 				AllocateIdentify: "containerd",
 				K8sPodNs:         "ns",
 			},
@@ -413,7 +719,7 @@ func TestValid(t *testing.T) {
 		{
 			name: "no k8sPodNs for type pod",
 			c: NetConf{
-				Type:       v1alpha1.AllocatedTypePod,
+				Type:       v1alpha1.AllocateTypePod,
 				K8sPodName: "pod",
 			},
 			isValid: false,
@@ -421,9 +727,54 @@ func TestValid(t *testing.T) {
 		{
 			name: "no AllocateIdentify for type cniused",
 			c: NetConf{
-				Type:       v1alpha1.AllocatedTypeCNIUsed,
+				Type:       v1alpha1.AllocateTypeCNIUsed,
 				K8sPodName: "pod",
 				K8sPodNs:   "ns",
+			},
+			isValid: false,
+		},
+		{
+			name: "valid for type statefulset",
+			c: NetConf{
+				Type:       v1alpha1.AllocateTypeStatefulSet,
+				K8sPodName: "pod",
+				K8sPodNs:   "ns",
+				Owner:      "ns/ss",
+				Pool:       "pool1",
+				IP:         "10.10.1.1",
+			},
+			isValid: true,
+		},
+		{
+			name: "no owner for type owner",
+			c: NetConf{
+				Type:       v1alpha1.AllocateTypeStatefulSet,
+				K8sPodName: "pod",
+				K8sPodNs:   "ns",
+				Pool:       "pool1",
+				IP:         "10.10.1.1",
+			},
+			isValid: false,
+		},
+		{
+			name: "no ippool for type statefulset",
+			c: NetConf{
+				Type:       v1alpha1.AllocateTypeStatefulSet,
+				K8sPodName: "pod",
+				K8sPodNs:   "ns",
+				Owner:      "ns/ss",
+				IP:         "10.10.1.1",
+			},
+			isValid: false,
+		},
+		{
+			name: "no ip for type statefulset",
+			c: NetConf{
+				Type:       v1alpha1.AllocateTypeStatefulSet,
+				K8sPodName: "pod",
+				K8sPodNs:   "ns",
+				Owner:      "ns/ss",
+				Pool:       "pool1",
 			},
 			isValid: false,
 		},

--- a/pkg/ipam/suit_test.go
+++ b/pkg/ipam/suit_test.go
@@ -10,6 +10,7 @@ import (
 	cniv1 "github.com/containernetworking/cni/pkg/types/100"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,6 +49,7 @@ var _ = BeforeSuite(func() {
 	scheme := scheme.Scheme
 	Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 	Expect(v1alpha1.AddToScheme(scheme)).Should(Succeed())
+	Expect(appsv1.AddToScheme(scheme)).Should(Succeed())
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -6,7 +6,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func GetAllocateIDFromPod(podNs, podName string) string {
+func GenOwner(ownerNs, ownerName string) string {
+	return ownerNs + "/" + ownerName
+}
+
+func GenAllocateIDFromPod(podNs, podName string) string {
 	return podNs + "/" + podName
 }
 


### PR DESCRIPTION
1.如果StatefulSet和Pod template 都指定了ippool或者IP，使用Pod template 指定的IPPool或者IP
2.statefulset 指定了IPPool, 使用指定的IPPool为statefulset 关联的Pod分配IP
3.statefulset 指定 ip-list, 从ip-list中为statefulset关联的Pod分配IP。且Pod重建保持IP不变。
4.删除指定 ip-list的statefulset子资源Pod不回收IP，删除statefulset时才回收IP