### PR TITLE
ci: add debug-test cmd to run unittest image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ test:
 
 docker-test: image-test
 	$(eval WORKDIR := /go/src/github.com/everoute/ipam)
+	docker run --rm -iu 0:0 -w $(WORKDIR) -v $(CURDIR):$(WORKDIR) localhost/unit-test make test
+
+debug-test: image-test
+	$(eval WORKDIR := /go/src/github.com/everoute/ipam)
 	docker run --rm -iu 0:0 -w $(WORKDIR) -v $(CURDIR):$(WORKDIR) localhost/unit-test bash
 
 prefix:


### PR DESCRIPTION
上一个pr不小心把docker-test命令的make test改掉了， 现在改回来。
新增debug-test命令用于开发环境调试