### PR TITLE
feat: ippool add attribute of private

### DIFF
--- a/api/ipam/v1alpha1/types.go
+++ b/api/ipam/v1alpha1/types.go
@@ -36,6 +36,7 @@ type IPPoolSpec struct {
 	//nolint: lll
 	// +kubebuilder:validation:Pattern="^(((([1]?\\d)?\\d|2[0-4]\\d|25[0-5])\\.){3}(([1]?\\d)?\\d|2[0-4]\\d|25[0-5]))|([\\da-fA-F]{1,4}(\\:[\\da-fA-F]{1,4}){7})|(([\\da-fA-F]{1,4}:){0,5}::([\\da-fA-F]{1,4}:){0,5}[\\da-fA-F]{1,4})$"
 	Gateway string `json:"gateway"`
+	Private bool   `json:"private,omitempty"`
 }
 
 // IPPoolStatus describe the current state of the IPPool

--- a/deploy/crds/ipam.everoute.io_ippools.yaml
+++ b/deploy/crds/ipam.everoute.io_ippools.yaml
@@ -44,6 +44,8 @@ spec:
                 description: 'Gateway must a valid IP in Subnet nolint: lll'
                 pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                 type: string
+              private:
+                type: boolean
               subnet:
                 description: 'Subnet is the total L2 network, nolint: lll'
                 pattern: ^(?:(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/([1-9]|[1-2]\d|3[0-2])$

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -325,6 +325,9 @@ func (i *Ipam) getTargetIPPool(ctx context.Context, conf *NetConf) (*v1alpha1.IP
 		return nil, "", err
 	}
 	for index, item := range ipPools.Items {
+		if ipPools.Items[index].Spec.Private {
+			continue
+		}
 		if ip := reallocateIP(conf, &ipPools.Items[index]); ip != "" {
 			err := i.updateRelocateIPStatus(ctx, conf, ip, &ipPools.Items[index])
 			return &ipPools.Items[index], ip, err
@@ -337,7 +340,7 @@ func (i *Ipam) getTargetIPPool(ctx context.Context, conf *NetConf) (*v1alpha1.IP
 		}
 	}
 	if ipPool.Name == "" {
-		return nil, "", fmt.Errorf("no IP address allocated in all pools")
+		return nil, "", fmt.Errorf("no IP address allocated in all public pools")
 	}
 	return ipPool, "", nil
 }


### PR DESCRIPTION
 add field ippool.Spec.Private
when ippool.Spec.Private=true, if pod doesn't specify pool, it can't allocate ip from this pool