### PR TITLE
fix(sks-4732): refine stale pod ip cleanup

### DIFF
--- a/api/ipam/v1alpha1/types.go
+++ b/api/ipam/v1alpha1/types.go
@@ -78,7 +78,8 @@ type IPPoolStatus struct {
 type AllocateInfo struct {
 	// Type=pod, ID=podns/name
 	ID string `json:"id"`
-	// Type=pod, CID=containerID
+	// Type=pod, CID=pod network/container instance ID.
+	// It is also used by ecp to derive vethBase when cleaning stale local links.
 	CID  string       `json:"cid,omitempty"`
 	Type AllocateType `json:"type"`
 	// Type=statefulset, owner=statefulsetns/name

--- a/deploy/crds/ipam.everoute.io_ippools.yaml
+++ b/deploy/crds/ipam.everoute.io_ippools.yaml
@@ -89,7 +89,9 @@ spec:
                 additionalProperties:
                   properties:
                     cid:
-                      description: Type=pod, CID=containerID
+                      description: Type=pod, CID=pod network/container instance ID.
+                        It is also used by ecp to derive vethBase when cleaning stale
+                        local links.
                       type: string
                     id:
                       description: Type=pod, ID=podns/name

--- a/pkg/cron/clean_stale_ip.go
+++ b/pkg/cron/clean_stale_ip.go
@@ -4,45 +4,93 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/everoute/ipam/api/ipam/v1alpha1"
 )
 
-type ProcessFun func(context.Context, client.Client, client.Reader)
+const (
+	podCleanQueueKey         = "stale-pod-ip-cleaner"
+	statefulSetCleanQueueKey = "stale-statefulset-ip-cleaner"
+)
 
-type CleanStaleIP struct {
-	period       time.Duration
-	k8sReader    client.Reader
-	k8sClient    client.Client
-	processFuncs []ProcessFun
+type podPendingKey struct {
+	Pool types.NamespacedName
+	IP   string
+	Pod  types.NamespacedName
 }
 
-func NewCleanStaleIP(period time.Duration, k8sClient client.Client, k8sReader client.Reader) *CleanStaleIP {
-	c := CleanStaleIP{
-		period:       period,
-		k8sReader:    k8sReader,
-		k8sClient:    k8sClient,
-		processFuncs: make([]ProcessFun, 0),
-	}
-	c.RegistryCleanFunc(cleanStaleIPForPod)
-	c.RegistryCleanFunc(cleanStaleIPForStatefulSet)
+type podPendingInfo struct {
+	AllocateInfo v1alpha1.AllocateInfo
+}
 
-	return &c
+type CleanStaleIP struct {
+	period          time.Duration
+	fastRetryPeriod time.Duration
+	k8sReader       client.Reader
+	k8sClient       client.Client
+	queue           workqueue.DelayingInterface
+	podPending      map[podPendingKey]podPendingInfo
+}
+
+func NewCleanStaleIP(period, fastRetryPeriod time.Duration, k8sClient client.Client, k8sReader client.Reader) *CleanStaleIP {
+	if fastRetryPeriod <= 0 || fastRetryPeriod > period {
+		fastRetryPeriod = period
+	}
+	return &CleanStaleIP{
+		period:          period,
+		fastRetryPeriod: fastRetryPeriod,
+		k8sReader:       k8sReader,
+		k8sClient:       k8sClient,
+		queue:           workqueue.NewNamedDelayingQueue("stale-ip"),
+		podPending:      make(map[podPendingKey]podPendingInfo),
+	}
 }
 
 func (c *CleanStaleIP) Run(ctx context.Context) {
-	go wait.NonSlidingUntilWithContext(ctx, c.process, c.period)
+	go func() {
+		<-ctx.Done()
+		c.queue.ShutDown()
+	}()
+
+	c.queue.Add(podCleanQueueKey)
+	c.queue.Add(statefulSetCleanQueueKey)
+
+	go func() {
+		for {
+			if !c.processNextItem(ctx) {
+				return
+			}
+		}
+	}()
 }
 
-func (c *CleanStaleIP) RegistryCleanFunc(f ProcessFun) {
-	if c.processFuncs == nil {
-		c.processFuncs = make([]ProcessFun, 0)
+func (c *CleanStaleIP) processNextItem(ctx context.Context) bool {
+	item, shutdown := c.queue.Get()
+	if shutdown {
+		return false
 	}
-	c.processFuncs = append(c.processFuncs, f)
-}
+	defer c.queue.Done(item)
 
-func (c *CleanStaleIP) process(ctx context.Context) {
-	for i := range c.processFuncs {
-		c.processFuncs[i](ctx, c.k8sClient, c.k8sReader)
+	key, ok := item.(string)
+	if !ok {
+		return true
 	}
+
+	switch key {
+	case podCleanQueueKey:
+		nextDelay := c.period
+		hasPending, err := c.cleanStaleIPForPod(ctx)
+		if err != nil || hasPending {
+			nextDelay = c.fastRetryPeriod
+		}
+		c.queue.AddAfter(podCleanQueueKey, nextDelay)
+	case statefulSetCleanQueueKey:
+		// Keep the original periodic cleanup flow for stale statefulset ips without fast retry.
+		cleanStaleIPForStatefulSet(ctx, c.k8sClient, c.k8sReader)
+		c.queue.AddAfter(statefulSetCleanQueueKey, c.period)
+	}
+	return true
 }

--- a/pkg/cron/pod.go
+++ b/pkg/cron/pod.go
@@ -7,21 +7,39 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/everoute/ipam/api/ipam/v1alpha1"
 	"github.com/everoute/ipam/pkg/constants"
 	"github.com/everoute/ipam/pkg/utils"
 )
 
-var _ ProcessFun = cleanStaleIPForPod
+type podAllocationState int
 
-func cleanStaleIPForPod(ctx context.Context, k8sClient client.Client, k8sReader client.Reader) {
+const (
+	podAllocationUsed podAllocationState = iota
+	podAllocationPending
+	podAllocationStale
+)
+
+func (c *CleanStaleIP) cleanStaleIPForPod(ctx context.Context) (hasPending bool, err error) {
+	nextPending := make(map[podPendingKey]podPendingInfo)
+	defer func() {
+		if err != nil {
+			c.podPending = make(map[podPendingKey]podPendingInfo)
+			klog.Infof("Found errors during pod stale scan, clear pending items and will fast retry")
+			hasPending = false
+			return
+		}
+		c.podPending = nextPending
+		klog.Infof("Update pod stale pending items to %v", c.podPending)
+		hasPending = len(c.podPending) > 0
+	}()
+
 	ippools := v1alpha1.IPPoolList{}
-	err := k8sClient.List(ctx, &ippools)
+	err = c.k8sClient.List(ctx, &ippools)
 	if err != nil {
 		klog.Errorf("Failed to list ippools, err: %v", err)
-		return
+		return false, err
 	}
 
 	for i := range ippools.Items {
@@ -37,76 +55,198 @@ func cleanStaleIPForPod(ctx context.Context, k8sClient client.Client, k8sReader 
 			if allo.Type != v1alpha1.AllocateTypePod {
 				continue
 			}
-			podNsName := utils.GetPodNsNameByAllocateID(allo.ID)
-			if podNsName.Name == "" || podNsName.Namespace == "" {
-				klog.Errorf("Can't get pod namespace and name for allocate info %v and ip %s in ippool %v", allo, ip, poolNsName)
-				continue
+			if processErr := c.processPodAllocation(
+				ctx, ip, allo, poolNsName, &ippools, nextPending,
+			); processErr != nil {
+				err = processErr
 			}
-			used, err := isIPUsedByPod(ctx, ip, podNsName, k8sClient, k8sReader)
-			if err != nil {
-				klog.Errorf("Failed to get pod %v for clean stale ip in ippool %v, err: %v", podNsName, poolNsName, err)
-				continue
-			}
-			if used {
-				continue
-			}
-			poolNow := v1alpha1.IPPool{}
-			if err := k8sClient.Get(ctx, poolNsName, &poolNow); err != nil {
-				klog.Errorf("Failed to get the latest ippool %s status, err: %s", poolNsName, err)
-				continue
-			}
-			alloNew, ok := poolNow.Status.AllocatedIPs[ip]
-			if !ok {
-				klog.Infof("Stale ip %s doesn't in latest ippool %s, skip update ippool status", ip, poolNsName)
-				continue
-			}
-			if alloNew != allo {
-				klog.Infof("Allocate info of stale ip %s in ippool %s has updated, old is %v, new is %v, skip update ippool status", ip, poolNsName, allo, alloNew)
-				continue
-			}
-			klog.Infof("IP %s for pod %s is stale, begin to cleanup from ippool %s", ip, podNsName, poolNsName)
-			delete(poolNow.Status.AllocatedIPs, ip)
-			if poolNow.Status.Offset == constants.IPPoolOffsetFull {
-				poolNow.Status.Offset = constants.IPPoolOffsetReset
-			}
-			poolNow.UpdateIPUsageCounter()
-			err = k8sClient.Status().Update(ctx, &poolNow)
-			if err != nil {
-				klog.Errorf("Failed to cleanup ippool %s stale ip %s, update ippool status err: %s", poolNsName, ip, err)
-			}
-			klog.Infof("Success to cleanup ippool %s stale ip %s for pod %s", poolNsName, ip, podNsName)
 		}
 	}
+	return false, err
 }
 
-func isIPUsedByPod(ctx context.Context, ip string, podNsName types.NamespacedName, k8sClient client.Client, k8sReader client.Reader) (bool, error) {
-	p := corev1.Pod{}
-	err := k8sClient.Get(ctx, podNsName, &p)
-	if err == nil {
-		if p.Status.PodIP == ip {
-			return true, nil
-		}
-	} else {
-		if !errors.IsNotFound(err) {
-			klog.Errorf("Failed to get pod %s, err: %s", podNsName, err)
-			return true, err
-		}
+func (c *CleanStaleIP) processPodAllocation(
+	ctx context.Context, ip string, allo v1alpha1.AllocateInfo,
+	poolNsName types.NamespacedName, ippools *v1alpha1.IPPoolList,
+	nextPending map[podPendingKey]podPendingInfo,
+) error {
+	podNsName := utils.GetPodNsNameByAllocateID(allo.ID)
+	if podNsName.Name == "" || podNsName.Namespace == "" {
+		klog.Errorf(
+			"Can't get pod namespace and name for allocate info %v and ip %s in ippool %v",
+			allo, ip, poolNsName,
+		)
+		return nil
 	}
 
-	err2 := k8sReader.Get(ctx, podNsName, &corev1.Pod{})
-	if err2 == nil {
-		if p.Status.PodIP == ip {
-			return true, nil
+	pendingKey := podPendingKey{Pool: poolNsName, IP: ip, Pod: podNsName}
+	state, err := c.isIPUsedByPod(ctx, ip, podNsName, ippools)
+	if err != nil {
+		klog.Errorf(
+			"Failed to get pod %v for clean stale ip in ippool %v, err: %v",
+			podNsName, poolNsName, err,
+		)
+		return err
+	}
+	if state == podAllocationUsed {
+		return nil
+	}
+	if state == podAllocationPending {
+		if pending, ok := c.podPending[pendingKey]; ok && pending.AllocateInfo == allo {
+			return c.cleanupStalePodAllocation(ctx, poolNsName, ip, allo, podNsName)
 		}
-		if p.Status.PodIP == "" {
+		nextPending[pendingKey] = podPendingInfo{AllocateInfo: allo}
+		klog.Infof(
+			"IP %s for pod %s in ippool %s has a newer ippool allocation for pod status ip, "+
+				"keep current allocation for a second confirmation",
+			ip, podNsName, poolNsName,
+		)
+		return nil
+	}
+	return c.cleanupStalePodAllocation(ctx, poolNsName, ip, allo, podNsName)
+}
+
+func (c *CleanStaleIP) cleanupStalePodAllocation(
+	ctx context.Context, poolNsName types.NamespacedName, ip string,
+	allo v1alpha1.AllocateInfo, podNsName types.NamespacedName,
+) error {
+	klog.Infof(
+		"IP %s with allocation %v is stale according to current pod state for pod %s, "+
+			"begin to cleanup stale allocation from ippool %s",
+		ip, allo, podNsName, poolNsName,
+	)
+	poolNow := v1alpha1.IPPool{}
+	if err := c.k8sClient.Get(ctx, poolNsName, &poolNow); err != nil {
+		klog.Errorf("Failed to get the latest ippool %s status, err: %s", poolNsName, err)
+		return err
+	}
+	alloNew, ok := poolNow.Status.AllocatedIPs[ip]
+	if !ok {
+		klog.Infof("Stale ip %s doesn't in latest ippool %s, skip update ippool status", ip, poolNsName)
+		return nil
+	}
+	if alloNew != allo {
+		klog.Infof(
+			"Allocate info of stale ip %s in ippool %s has updated, old is %v, new is %v, "+
+				"skip update ippool status",
+			ip, poolNsName, allo, alloNew,
+		)
+		return nil
+	}
+	delete(poolNow.Status.AllocatedIPs, ip)
+	if poolNow.Status.Offset == constants.IPPoolOffsetFull {
+		poolNow.Status.Offset = constants.IPPoolOffsetReset
+	}
+	poolNow.UpdateIPUsageCounter()
+	if err := c.k8sClient.Status().Update(ctx, &poolNow); err != nil {
+		klog.Errorf("Failed to cleanup ippool %s stale ip %s, update ippool status err: %s", poolNsName, ip, err)
+		return err
+	}
+	klog.Infof(
+		"Success to cleanup ippool %s stale ip %s with allocation %v for pod %s",
+		poolNsName, ip, allo, podNsName,
+	)
+	return nil
+}
+
+func (c *CleanStaleIP) isIPUsedByPod(
+	ctx context.Context, ip string, podNsName types.NamespacedName,
+	ippools *v1alpha1.IPPoolList,
+) (podAllocationState, error) {
+	p := corev1.Pod{}
+	err := c.k8sClient.Get(ctx, podNsName, &p)
+	if err == nil {
+		if podHasIP(&p, ip) {
+			return podAllocationUsed, nil
+		}
+	} else if !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get pod %s, err: %s", podNsName, err)
+		return podAllocationUsed, err
+	}
+
+	p = corev1.Pod{}
+	err = c.k8sReader.Get(ctx, podNsName, &p)
+	if err == nil {
+		if podHasIP(&p, ip) {
+			return podAllocationUsed, nil
+		}
+
+		if p.Status.PodIP == "" && len(p.Status.PodIPs) == 0 {
 			klog.Infof("Can't get pod %s ip, keep ip %s allocate info in ippool", podNsName, ip)
-			return true, nil
+			return podAllocationUsed, nil
 		}
-		return false, nil
+		currentPodID := utils.GenAllocateIDFromPod(podNsName.Namespace, podNsName.Name)
+		allocations := getAllocatedPodByIPs(ippools, getPodIPs(&p))
+		for podIP, allo := range allocations {
+			if allo.ID == currentPodID {
+				klog.Infof(
+					"Pod %s still exists in phase %s and pod status ip %s has another ippool allocation "+
+						"for the same pod, mark allocated ip %s as pending stale",
+					podNsName, p.Status.Phase, podIP, ip,
+				)
+				return podAllocationPending, nil
+			}
+		}
+		if len(allocations) > 0 {
+			klog.Infof(
+				"Pod %s still exists in phase %s, but none of status ip allocations %v belongs to "+
+					"current pod, keep allocated ip %s",
+				podNsName, p.Status.Phase, allocations, ip,
+			)
+			return podAllocationUsed, nil
+		}
+		klog.Infof(
+			"Pod %s still exists in phase %s but current pod ip %s and pod ips %v don't match "+
+				"allocated ip %s, and pod status ips aren't allocated in ippool, keep allocation",
+			podNsName, p.Status.Phase, p.Status.PodIP, p.Status.PodIPs, ip,
+		)
+		return podAllocationUsed, nil
 	}
-	if !errors.IsNotFound(err2) {
-		klog.Errorf("Failed to get pod %v, err: %v", podNsName, err)
-		return true, err
+	if !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get pod %s, err: %s", podNsName, err)
+		return podAllocationUsed, err
 	}
-	return false, nil
+	klog.Infof("Pod %s is not found from uncached reader, mark allocated ip %s as stale", podNsName, ip)
+	return podAllocationStale, nil
+}
+
+func podHasIP(pod *corev1.Pod, ip string) bool {
+	if pod.Status.PodIP == ip {
+		return true
+	}
+	for _, podIP := range pod.Status.PodIPs {
+		if podIP.IP == ip {
+			return true
+		}
+	}
+	return false
+}
+
+func getAllocatedPodByIPs(ippools *v1alpha1.IPPoolList, ips []string) map[string]v1alpha1.AllocateInfo {
+	res := make(map[string]v1alpha1.AllocateInfo)
+	for _, ip := range ips {
+		for i := range ippools.Items {
+			allo, ok := ippools.Items[i].Status.AllocatedIPs[ip]
+			if !ok {
+				continue
+			}
+			res[ip] = allo
+			break
+		}
+	}
+	return res
+}
+
+func getPodIPs(pod *corev1.Pod) []string {
+	res := make([]string, 0, len(pod.Status.PodIPs)+1)
+	if pod.Status.PodIP != "" {
+		res = append(res, pod.Status.PodIP)
+	}
+	for _, podIP := range pod.Status.PodIPs {
+		if podIP.IP == "" || podIP.IP == pod.Status.PodIP {
+			continue
+		}
+		res = append(res, podIP.IP)
+	}
+	return res
 }

--- a/pkg/cron/pod_test.go
+++ b/pkg/cron/pod_test.go
@@ -1,0 +1,216 @@
+package cron
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/everoute/ipam/api/ipam/v1alpha1"
+)
+
+func TestIsIPUsedByPod(t *testing.T) {
+	t.Run("pending when pod status ip is allocated to the same pod", func(t *testing.T) {
+		reader := newFakeReader(t, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodRunning,
+				PodIP:  "10.10.65.2",
+				PodIPs: []corev1.PodIP{{IP: "10.10.65.2"}},
+			},
+		})
+		ippools := v1alpha1.IPPoolList{Items: []v1alpha1.IPPool{{
+			Status: v1alpha1.IPPoolStatus{
+				AllocatedIPs: map[string]v1alpha1.AllocateInfo{
+					"10.10.65.2": {Type: v1alpha1.AllocateTypePod, ID: "ns1/pod1"},
+				},
+			},
+		}}}
+		c := &CleanStaleIP{k8sClient: newFakeClient(reader), k8sReader: reader}
+		state, err := c.isIPUsedByPod(context.Background(), "10.10.65.1", types.NamespacedName{Namespace: "ns1", Name: "pod1"}, &ippools)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if state != podAllocationPending {
+			t.Fatalf("expected pending, got %v", state)
+		}
+	})
+
+	t.Run("used when pod status ip is not allocated in ippool", func(t *testing.T) {
+		reader := newFakeReader(t, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodRunning,
+				PodIP:  "10.10.65.2",
+				PodIPs: []corev1.PodIP{{IP: "10.10.65.2"}},
+			},
+		})
+		ippools := v1alpha1.IPPoolList{}
+		c := &CleanStaleIP{k8sClient: newFakeClient(reader), k8sReader: reader}
+		state, err := c.isIPUsedByPod(context.Background(), "10.10.65.1", types.NamespacedName{Namespace: "ns1", Name: "pod1"}, &ippools)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if state != podAllocationUsed {
+			t.Fatalf("expected used, got %v", state)
+		}
+	})
+
+	t.Run("used when pod status ip is allocated to another pod", func(t *testing.T) {
+		reader := newFakeReader(t, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodRunning,
+				PodIP:  "10.10.65.2",
+				PodIPs: []corev1.PodIP{{IP: "10.10.65.2"}},
+			},
+		})
+		ippools := v1alpha1.IPPoolList{Items: []v1alpha1.IPPool{{
+			Status: v1alpha1.IPPoolStatus{
+				AllocatedIPs: map[string]v1alpha1.AllocateInfo{
+					"10.10.65.2": {Type: v1alpha1.AllocateTypePod, ID: "ns1/pod2"},
+				},
+			},
+		}}}
+		c := &CleanStaleIP{k8sClient: newFakeClient(reader), k8sReader: reader}
+		state, err := c.isIPUsedByPod(context.Background(), "10.10.65.1", types.NamespacedName{Namespace: "ns1", Name: "pod1"}, &ippools)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if state != podAllocationUsed {
+			t.Fatalf("expected used, got %v", state)
+		}
+	})
+
+	t.Run("pending when one of pod status ips is allocated to the same pod", func(t *testing.T) {
+		reader := newFakeReader(t, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodRunning,
+				PodIP:  "10.10.65.2",
+				PodIPs: []corev1.PodIP{{IP: "10.10.65.2"}, {IP: "10.10.65.3"}},
+			},
+		})
+		ippools := v1alpha1.IPPoolList{Items: []v1alpha1.IPPool{{
+			Status: v1alpha1.IPPoolStatus{
+				AllocatedIPs: map[string]v1alpha1.AllocateInfo{
+					"10.10.65.3": {Type: v1alpha1.AllocateTypePod, ID: "ns1/pod1"},
+				},
+			},
+		}}}
+		c := &CleanStaleIP{k8sClient: newFakeClient(reader), k8sReader: reader}
+		state, err := c.isIPUsedByPod(context.Background(), "10.10.65.1", types.NamespacedName{Namespace: "ns1", Name: "pod1"}, &ippools)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if state != podAllocationPending {
+			t.Fatalf("expected pending, got %v", state)
+		}
+	})
+
+	t.Run("stale when pod is not found", func(t *testing.T) {
+		reader := newFakeReader(t)
+		ippools := v1alpha1.IPPoolList{}
+
+		c := &CleanStaleIP{k8sClient: newFakeClient(reader), k8sReader: reader}
+		state, err := c.isIPUsedByPod(context.Background(), "10.10.65.1", types.NamespacedName{Namespace: "ns1", Name: "pod1"}, &ippools)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if state != podAllocationStale {
+			t.Fatalf("expected stale, got %v", state)
+		}
+	})
+}
+
+func newFakeReader(t *testing.T, objs ...client.Object) client.Reader {
+	t.Helper()
+	r := &staticReader{}
+	for _, obj := range objs {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok {
+			t.Fatalf("unsupported object type %T", obj)
+		}
+		podCopy := pod.DeepCopy()
+		r.pods = append(r.pods, podCopy)
+	}
+	return r
+}
+
+type staticReader struct {
+	pods []*corev1.Pod
+}
+
+func (r *staticReader) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+	for _, item := range r.pods {
+		if item.Namespace == key.Namespace && item.Name == key.Name {
+			*pod = *item.DeepCopy()
+			return nil
+		}
+	}
+	return apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, key.Name)
+}
+
+func (r *staticReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return nil
+}
+
+type fakeClient struct {
+	reader client.Reader
+}
+
+func newFakeClient(reader client.Reader) client.Client {
+	return &fakeClient{reader: reader}
+}
+
+func (f *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return f.reader.Get(ctx, key, obj, opts...)
+}
+
+func (f *fakeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return f.reader.List(ctx, list, opts...)
+}
+
+func (f *fakeClient) Create(context.Context, client.Object, ...client.CreateOption) error { return nil }
+func (f *fakeClient) Delete(context.Context, client.Object, ...client.DeleteOption) error { return nil }
+func (f *fakeClient) Update(context.Context, client.Object, ...client.UpdateOption) error { return nil }
+func (f *fakeClient) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
+	return nil
+}
+func (f *fakeClient) DeleteAllOf(context.Context, client.Object, ...client.DeleteAllOfOption) error {
+	return nil
+}
+func (f *fakeClient) Status() client.SubResourceWriter            { return fakeSubResourceClient{} }
+func (f *fakeClient) SubResource(string) client.SubResourceClient { return fakeSubResourceClient{} }
+func (f *fakeClient) Scheme() *runtime.Scheme                     { return runtime.NewScheme() }
+func (f *fakeClient) RESTMapper() meta.RESTMapper                 { return nil }
+func (f *fakeClient) GroupVersionKindFor(runtime.Object) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+func (f *fakeClient) IsObjectNamespaced(runtime.Object) (bool, error) { return true, nil }
+
+type fakeSubResourceClient struct{}
+
+func (fakeSubResourceClient) Create(context.Context, client.Object, client.Object, ...client.SubResourceCreateOption) error {
+	return nil
+}
+func (fakeSubResourceClient) Update(context.Context, client.Object, ...client.SubResourceUpdateOption) error {
+	return nil
+}
+func (fakeSubResourceClient) Patch(context.Context, client.Object, client.Patch, ...client.SubResourcePatchOption) error {
+	return nil
+}
+func (fakeSubResourceClient) Get(context.Context, client.Object, client.Object, ...client.SubResourceGetOption) error {
+	return nil
+}

--- a/pkg/cron/statefulset.go
+++ b/pkg/cron/statefulset.go
@@ -14,8 +14,6 @@ import (
 	"github.com/everoute/ipam/pkg/utils"
 )
 
-var _ ProcessFun = cleanStaleIPForStatefulSet
-
 func cleanStaleIPForStatefulSet(ctx context.Context, k8sClient client.Client, k8sReader client.Reader) {
 	ippools := v1alpha1.IPPoolList{}
 	err := k8sClient.List(ctx, &ippools)

--- a/pkg/cron/suit_test.go
+++ b/pkg/cron/suit_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient.Create(ctx, &nsObj)).Should(Succeed())
 
 	By("init CleanStaleIP")
-	cleanStaleIP = NewCleanStaleIP(period, k8sClient, k8sClient)
+	cleanStaleIP = NewCleanStaleIP(period, period, k8sClient, k8sClient)
 
 	By("cleanStaleIP.Run")
 	cleanStaleIP.Run(ctrl.SetupSignalHandler())


### PR DESCRIPTION
## Purpose
修复 stale pod IP 清理中的误判问题，避免 Pod 状态中的 IP 尚未同步时直接回收分配信息；同时保留 statefulset stale IP 的原有周期清理逻辑。

## Changes
- 调整 pod stale IP 清理为独立的队列 key，并在存在 pending 或错误时使用更短周期重试。
- 将 Pod IP 的最终比较基准调整为 API reader 直读到的最新 Pod 状态，缓存 client 仅用于正常场景下的快速短路。
- 修正 Pod stale 判断逻辑：结合 API 直读结果和 IPPool 分配信息判断 used、pending、stale。
- 为 pod stale cleanup 增加 pending 管理与相关日志，并补充对应单测。
- 保持 statefulset stale cleanup 为原有固定周期处理，不引入快速重试。
- 补充 AllocateInfo.CID 的注释，说明其在本地 stale link 清理中的用途。

## Tests
- `go test /root/workspace/ipam/pkg/cron -run TestIsIPUsedByPod`
- `go test /root/workspace/ipam/pkg/cron -run TestDoesNotExist`
